### PR TITLE
Add ICMPv6 decoding

### DIFF
--- a/probe_decode.go
+++ b/probe_decode.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"net"
 	"time"
 
@@ -19,8 +18,8 @@ func (pm *ProbeManager) decodeRecvProbe(packet gopacket.Packet) (ttl uint8, prob
 		ttl, probeNum, port, _ = pm.decodeICMPv4Layer(icmp4Layer.(*layers.ICMPv4))
 		flag = "TTL"
 	} else if icmp6Layer := packet.Layer(layers.LayerTypeICMPv6); icmp6Layer != nil {
-		// TODO: implement decodeICMPv6Layer()
-		fmt.Println("ICMPv6 decode not implemented yet")
+		ttl, probeNum, port, _ = pm.decodeICMPv6Layer(icmp6Layer.(*layers.ICMPv6))
+		flag = "TTL"
 	} else {
 		switch pm.probeConfig.protocolConfig.transport {
 		case layers.IPProtocolTCP:

--- a/probe_decode_icmp.go
+++ b/probe_decode_icmp.go
@@ -72,10 +72,123 @@ func (pm *ProbeManager) decodeICMPv4Layer(icmp4Layer *layers.ICMPv4) (ttl uint8,
 	return
 }
 
+// decodeICMPv6Layer decodes an ICMPv6 layer and returns the TTL, probe number, port, and flag.
+func (pm *ProbeManager) decodeICMPv6Layer(icmp6Layer *layers.ICMPv6) (ttl uint8, probeNum uint, port uint, flag string) {
+	if icmp6Layer.TypeCode.Type() == layers.ICMPv6TypeTimeExceeded && icmp6Layer.TypeCode.Code() == layers.ICMPv6CodeHopLimitExceeded {
+		innerPayload := icmp6Layer.Payload
+		expectedLayer := protoToLayerType(pm.probeConfig.protocolConfig.inet)
+
+		if pm.probeConfig.protocolConfig.inet == layers.IPProtocolIPv6 {
+			offset, ok := locateInnerIPv6Header(innerPayload)
+			if !ok {
+				return
+			}
+			innerPayload = innerPayload[offset:]
+		}
+
+		if len(innerPayload) == 0 {
+			return
+		}
+
+		if packet := gopacket.NewPacket(innerPayload, expectedLayer, gopacket.Default); packet != nil {
+			inetLayer := packet.Layer(expectedLayer)
+			if inetLayer == nil {
+				return
+			}
+
+			// Verify source and destination IP addresses
+			switch pm.probeConfig.protocolConfig.inet {
+			case layers.IPProtocolIPv4:
+				if src := inetLayer.(*layers.IPv4).SrcIP; !src.Equal(net.IP(pm.probeConfig.route.Source.AsSlice())) {
+					return
+				} else if dst := inetLayer.(*layers.IPv4).DstIP; !dst.Equal(net.IP(pm.probeConfig.route.Destination.AsSlice())) {
+					return
+				}
+			case layers.IPProtocolIPv6:
+				if src := inetLayer.(*layers.IPv6).SrcIP; !src.Equal(net.IP(pm.probeConfig.route.Source.AsSlice())) {
+					return
+				} else if dst := inetLayer.(*layers.IPv6).DstIP; !dst.Equal(net.IP(pm.probeConfig.route.Destination.AsSlice())) {
+					return
+				}
+			}
+
+			// Verify source and destination ports.
+			//
+			// If we have an ErrorLayer, we're probably looking at a truncated TCP header, so we'll try
+			// to decode this before potentially checking a TCP layer that gopacket failed to decode.
+			if errorLayer := packet.Layer(gopacket.LayerTypeDecodeFailure); errorLayer != nil {
+				payload := inetLayer.LayerPayload()
+				if len(payload) < 8 {
+					return
+				}
+				if srcPort := binary.BigEndian.Uint16(payload[:2]); !pm.sourcePortWithinRange(srcPort) {
+					return
+				} else if dstPort := binary.BigEndian.Uint16(payload[2:4]); dstPort != pm.probeConfig.dstPort {
+					return
+				} else {
+					ttl, probeNum = decodeTTLAndProbe(binary.BigEndian.Uint32(payload[4:8]))
+					port = uint(srcPort)
+					return
+				}
+			}
+			if tcpLayer := packet.Layer(layers.LayerTypeTCP); tcpLayer != nil {
+				if srcPort := tcpLayer.(*layers.TCP).SrcPort; !pm.sourcePortWithinRange(uint16(srcPort)) {
+					return
+				} else if dstPort := tcpLayer.(*layers.TCP).DstPort; dstPort != layers.TCPPort(pm.probeConfig.dstPort) {
+					return
+				}
+				ttl, probeNum, port, flag = decodeTCPLayer(tcpLayer.(*layers.TCP))
+				return
+			}
+			if udpLayer := packet.Layer(layers.LayerTypeUDP); udpLayer != nil {
+				if srcPort := udpLayer.(*layers.UDP).SrcPort; !pm.sourcePortWithinRange(uint16(srcPort)) {
+					return
+				} else if dstPort := udpLayer.(*layers.UDP).DstPort; dstPort != layers.UDPPort(pm.probeConfig.dstPort) {
+					return
+				}
+				ttl, probeNum, port = decodeUDPLayer(udpLayer.(*layers.UDP))
+				return
+			}
+		}
+	}
+	return
+}
+
+// locateInnerIPv6Header scans the provided payload to locate the start of an
+// inner IPv6 header. It checks for the presence of an IPv6 header by examining
+// the version field in the first nibble of each potential header location.
+//
+// The function returns the offset of the inner IPv6 header within the payload
+// and a boolean indicating whether an IPv6 header was found.
+func locateInnerIPv6Header(payload []byte) (int, bool) {
+	if len(payload) < 40 {
+		return 0, false
+	}
+
+	if payload[0]>>4 == 6 {
+		return 0, true
+	}
+
+	if len(payload) >= 44 && payload[4]>>4 == 6 {
+		return 4, true
+	}
+
+	for offset := 1; offset+40 <= len(payload); offset++ {
+		if payload[offset]>>4 == 6 {
+			return offset, true
+		}
+	}
+
+	return 0, false
+}
+
+// sourcePortWithinRange checks if the given source port falls within the range
+// allocated for this probe manager's probes.
 func (pm *ProbeManager) sourcePortWithinRange(srcPort uint16) bool {
 	return srcPort >= uint16(pm.probeConfig.srcPort) && srcPort < uint16(pm.probeConfig.srcPort+pm.parallelProbes)
 }
 
+// protoToLayerType maps an IPProtocol to the corresponding gopacket LayerType.
 func protoToLayerType(proto layers.IPProtocol) gopacket.LayerType {
 	switch proto {
 	case layers.IPProtocolIPv4:


### PR DESCRIPTION
This PR adds a pm.decodeICMPv6Layer function that finally adds full IPv6 probe support.

Resolves https://github.com/tkjaer/etr/issues/2