### PR TITLE
Fix nil pointer dereference in ProbeManager.updateReceivedStats

### DIFF
--- a/internal/probe/probe_manager_stats.go
+++ b/internal/probe/probe_manager_stats.go
@@ -230,6 +230,8 @@ func (pm *ProbeManager) updateReceivedStats(probeID uint16, data *ProbeEventData
 			if blankStats, ok := hopStats.IPs[""]; ok {
 				ipStats = blankStats
 				delete(hopStats.IPs, "")
+			} else {
+				ipStats = &shared.HopIPStats{}
 			}
 		} else {
 			ipStats = &shared.HopIPStats{}


### PR DESCRIPTION
The bug was that when hopStats.IPs contains exactly one entry but it's not a blank entry (empty string key), ipStats would remain nil. This causes a nil pointer dereference when trying to access ipStats.PTR on line 243.

Thanks to @jrogers512 for reporting the issue.

Fixes https://github.com/tkjaer/etr/issues/57