### PR TITLE
Fix ICMP regression introduced in commit 9f4b6e2

### DIFF
--- a/internal/probe/probe_decode_icmp.go
+++ b/internal/probe/probe_decode_icmp.go
@@ -66,7 +66,8 @@ func (pm *ProbeManager) decodeICMPv4Layer(icmp4Layer *layers.ICMPv4) (ttl uint8,
 				} else if dstPort := tcpLayer.(*layers.TCP).DstPort; dstPort != layers.TCPPort(pm.probeConfig.dstPort) {
 					return
 				}
-				ttl, probeNum, port, flag = decodeTCPLayer(tcpLayer.(*layers.TCP))
+				ttl, probeNum, port, _ = decodeTCPLayer(tcpLayer.(*layers.TCP))
+				// Keep the ICMP-level flag (TTL or D) rather than TCP flags
 				return
 			}
 			if udpLayer := packet.Layer(layers.LayerTypeUDP); udpLayer != nil {
@@ -157,7 +158,8 @@ func (pm *ProbeManager) decodeICMPv6Layer(icmp6Layer *layers.ICMPv6) (ttl uint8,
 				} else if dstPort := tcpLayer.(*layers.TCP).DstPort; dstPort != layers.TCPPort(pm.probeConfig.dstPort) {
 					return
 				}
-				ttl, probeNum, port, flag = decodeTCPLayer(tcpLayer.(*layers.TCP))
+				ttl, probeNum, port, _ = decodeTCPLayer(tcpLayer.(*layers.TCP))
+				// Keep the ICMP-level flag (TTL or D) rather than TCP flags
 				return
 			}
 			if udpLayer := packet.Layer(layers.LayerTypeUDP); udpLayer != nil {


### PR DESCRIPTION
Fix ICMP probe decoding to retain ICMP-level flags rather than overwriting them with TCP flags.

Thanks to Sander van Delden <@SanderDelden> for reporting this issue!

Resolves https://github.com/tkjaer/etr/issues/64